### PR TITLE
command `gotour` with japanese translated contents

### DIFF
--- a/README
+++ b/README
@@ -2,7 +2,7 @@ This is Go Tour, an introduction to the Go programming language.
 
 To install the tour locally, first install Go, then run:
 
-	$ go get golang.org/x/tour/gotour
+	$ go get github.com/atotto/go-tour-jp/gotour
 	$ cd $GOPATH/bin
 	$ ./gotour
 

--- a/gotour/local.go
+++ b/gotour/local.go
@@ -31,7 +31,7 @@ import (
 )
 
 const (
-	basePkg    = "golang.org/x/tour/"
+	basePkg    = "github.com/atotto/go-tour-jp/"
 	socketPath = "/socket"
 )
 

--- a/gotour/tour.go
+++ b/gotour/tour.go
@@ -2,7 +2,7 @@
 // Use of this source code is governed by a BSD-style
 // license that can be found in the LICENSE file.
 
-package main // import "golang.org/x/tour/gotour"
+package main // import "github.com/atotto/go-tour-jp/gotour"
 
 import (
 	"bytes"


### PR DESCRIPTION
go getできるようにしました:

```
$ go get github.com/atotto/go-tour-jp/gotour
```

で日本語版のgotourをローカルで起動できます。
