### PR TITLE
Make the translation follow the original

### DIFF
--- a/content/moretypes.article
+++ b/content/moretypes.article
@@ -237,7 +237,7 @@ Slices can contain any type, including other slices.
 
 インデックスや値は、 " `_` "(アンダーバー) へ代入することで捨てることができます。
 
-もしインデックスだけが必要なのであれば、例のコードの場合 " `,`value` " の部分を `_` にします。
+もしインデックスだけが必要なのであれば、 " `,`value` " を省略します。
 
 .play moretypes/range-continued.go
 


### PR DESCRIPTION
The original text is `If you only want the index, drop the ", value" entirely.`.
