### PR TITLE
文章中の括弧の不整合の修正

### DIFF
--- a/content/concurrency.article
+++ b/content/concurrency.article
@@ -105,7 +105,7 @@ closeするのは、これ以上値が来ないことを受け手が知る必要
 
 * Exercise: Equivalent Binary Trees
 
-葉に同じ順序の値を保持する、異なる多くの[[https://ja.wikipedia.org/wiki/二分木][二分木( _binary_tree_ )]]]があります。
+葉に同じ順序の値を保持する、異なる多くの[[https://ja.wikipedia.org/wiki/二分木][二分木( _binary_tree_ )]]があります。
 例えば、ここに "1, 1, 2, 3, 5, 8, 13" を保持する2つの二分木があります。
 
 .image /content/img/tree.png

--- a/content/methods.article
+++ b/content/methods.article
@@ -378,7 +378,7 @@ Note: `Bounds` メソッドの戻り値である `Rectangle` は、 `image` パ�
 
 * Exercise: Images
 
-前に解いた、 [[/moretypes/18][画像ジェネレーター]] を覚えていますか？
+前に解いた、 [[/moretypes/18][画像ジェネレーター]]　を覚えていますか？
 今回は、データのスライスの代わりに `image.Image` インタフェースの実装を返すようにしてみましょう。
 
 自分の `Image` 型を定義し、 [[https://golang.org/pkg/image/#Image][インタフェースを満たすのに必要なメソッド]] を実装し、 `pic.ShowImage` を呼び出してみてください。

--- a/content/methods.article
+++ b/content/methods.article
@@ -396,6 +396,5 @@ Note: `Bounds` メソッドの戻り値である `Rectangle` は、 `image` パ�
 
 この章はこれで終わりです。
 
-A
 [[/list][章のリスト]]から学びたいところを見ても良いですし、
 [[javascript:click('.next-page')][>]] をクリックして次の章へ進みましょう。

--- a/content/methods.article
+++ b/content/methods.article
@@ -378,7 +378,7 @@ Note: `Bounds` メソッドの戻り値である `Rectangle` は、 `image` パ�
 
 * Exercise: Images
 
-前に解いた、 [[/moretypes/18][画像ジェネレーター]]　を覚えていますか？
+前に解いた、 [[/moretypes/18][画像ジェネレーター]] を覚えていますか？
 今回は、データのスライスの代わりに `image.Image` インタフェースの実装を返すようにしてみましょう。
 
 自分の `Image` 型を定義し、 [[https://golang.org/pkg/image/#Image][インタフェースを満たすのに必要なメソッド]] を実装し、 `pic.ShowImage` を呼び出してみてください。
@@ -396,5 +396,6 @@ Note: `Bounds` メソッドの戻り値である `Rectangle` は、 `image` パ�
 
 この章はこれで終わりです。
 
+A
 [[/list][章のリスト]]から学びたいところを見ても良いですし、
 [[javascript:click('.next-page')][>]] をクリックして次の章へ進みましょう。


### PR DESCRIPTION
## REF
https://go-tour-jp.appspot.com/concurrency/7

## WHAT
`concurrency.article` 内に，[二分木( binary tree )](https://ja.wikipedia.org/wiki/%E4%BA%8C%E5%88%86%E6%9C%A8) へのリンクを表す箇所が存在するが，
括弧の整合性が取れておらず，web ページ上で不適切な表示になっていたので修正しました．

## 画像
<img width="176" alt="スクリーンショット 2020-08-30 22 43 48" src="https://user-images.githubusercontent.com/47474057/91660697-4ce16500-eb12-11ea-8d2d-3cfb71450398.png">
