### PR TITLE
Fix a command from gotour to tour to run tour

### DIFF
--- a/content/welcome.article
+++ b/content/welcome.article
@@ -91,9 +91,9 @@ The tour is available in other languages:
 #appengine: 上記のコマンドの実行に問題がある場合は手動でこのツアーをインストールして実行できます:
 #appengine: 
 #appengine:   go get github.com/atotto/go-tour-jp/gotour
-#appengine:   gotour
+#appengine:   tour
 #appengine: 
-#appengine: gotour ではローカルバージョンの tour を表示するウェブブラウザが開きます。
+#appengine: tour ではローカルバージョンの tour を表示するウェブブラウザが開きます。
 #appengine: 
 #appengine: もちろん、ここのウェブサイトでGo Tourを続けてもらって構いません。
 


### PR DESCRIPTION
ローカルバージョンのツアーを実行するコマンドが `gotour` から `tour` に代わっているようなので、それに合わせて該当ページを修正しました。

現在、[こちら](https://go-tour-jp.appspot.com/welcome/3)のページに従って、`gotour` コマンドを実行すると、次のメッセージが表示されてしまっています。
```
$ gotour
golang.org/x/tour/gotour has moved to golang.org/x/tour
```